### PR TITLE
Increase ffi-rzmq dependency version to 2.0.x, minimum 2.0.4

### DIFF
--- a/logstash-input-zeromq.gemspec
+++ b/logstash-input-zeromq.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-zeromq'
-  s.version         = '0.1.3'
+  s.version         = '0.1.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "$summary"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
 
   s.add_runtime_dependency 'logstash-codec-json'
-  s.add_runtime_dependency 'ffi-rzmq'
+  s.add_runtime_dependency 'ffi-rzmq', '~> 2.0.4'
   s.add_development_dependency 'logstash-devutils'
 end
-


### PR DESCRIPTION
This fixes an incompatibly with my plugin that requires latest ffi-rzmq for CurveZMQ features.

Also updated version number (hope it isn't a step too far!)
