### PR TITLE
Make usage of the new stop semantics to properly shutdown the plugin

### DIFF
--- a/lib/logstash/util/zeromq.rb
+++ b/lib/logstash/util/zeromq.rb
@@ -3,13 +3,12 @@ require 'ffi-rzmq'
 require "logstash/namespace"
 
 module LogStash::Util::ZeroMQ
-  CONTEXT = ZMQ::Context.new
   # LOGSTASH-400
   # see https://github.com/chuckremes/ffi-rzmq/blob/master/lib/ffi-rzmq/socket.rb#L93-117
   STRING_OPTS = %w{IDENTITY SUBSCRIBE UNSUBSCRIBE}
 
   def context
-    CONTEXT
+    @context ||= ZMQ::Context.new
   end
 
   def setup(socket, address)

--- a/spec/inputs/zeromq_spec.rb
+++ b/spec/inputs/zeromq_spec.rb
@@ -14,6 +14,14 @@ describe LogStash::Inputs::ZeroMQ, :zeromq => true do
       expect { plugin.close }.to_not raise_error
     end
 
-  end
+    context "when interrupting the plugin" do
+      it_behaves_like "an interruptible input plugin" do
+        let(:config) { { "topology" => "pushpull" } }
+        after do
+          subject.close
+        end
+      end
+    end
 
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,7 +23,7 @@ module ZeroMQHelpers
     result = size.times.inject([]) do |acc|
       acc << queue.pop
     end
-    plugin.close
+    plugin.do_stop
     pipeline_thread.join
     result
   end # def input


### PR DESCRIPTION
Implements `stop` to return from `run` according to https://github.com/elastic/logstash/issues/3210

Depends on https://github.com/elastic/logstash-devutils/pull/32 and https://github.com/elastic/logstash/pull/3812

Fixes #9 
