### PR TITLE
Adding 5ms sleep to non-blocking output_queue loop

### DIFF
--- a/lib/logstash/inputs/zeromq.rb
+++ b/lib/logstash/inputs/zeromq.rb
@@ -130,7 +130,7 @@ class LogStash::Inputs::ZeroMQ < LogStash::Inputs::Base
         # Get the first part as the msg
         m1 = ""
         rc = @zsocket.recv_string(m1, ZMQ::DONTWAIT)
-        next if rc == -1 && ZMQ::Util.errno == ZMQ::EAGAIN
+        next if rc == -1 && ZMQ::Util.errno == ZMQ::EAGAIN && sleep(0.005)
         error_check(rc, "in recv_string")
 
         @logger.debug("ZMQ receiving", :event => m1)


### PR DESCRIPTION
https://github.com/logstash-plugins/logstash-input-zeromq/issues/13
