### PR TITLE
Bug close exception

### DIFF
--- a/lib/logstash/inputs/zeromq.rb
+++ b/lib/logstash/inputs/zeromq.rb
@@ -114,11 +114,7 @@ class LogStash::Inputs::ZeroMQ < LogStash::Inputs::Base
   end # def register
 
   def teardown
-    begin
-      error_check(@zsocket.close, "while closing the zmq socket")
-    rescue RuntimeError => e
-      @logger.error("Failed to properly teardown ZeroMQ")
-    end
+    error_check(@zsocket.close, "while closing the zmq socket")
   end # def teardown
 
   def server?

--- a/lib/logstash/inputs/zeromq.rb
+++ b/lib/logstash/inputs/zeromq.rb
@@ -114,8 +114,12 @@ class LogStash::Inputs::ZeroMQ < LogStash::Inputs::Base
   end # def register
 
   def close
-    error_check(@zsocket.close, "while closing the zmq socket")
-    context.terminate
+    begin
+      error_check(@zsocket.close, "while closing the zmq socket")
+      context.terminate
+    rescue RuntimeError => e
+      @logger.error("Failed to properly teardown ZeroMQ")
+    end
   end # def close
 
   def server?

--- a/lib/logstash/inputs/zeromq.rb
+++ b/lib/logstash/inputs/zeromq.rb
@@ -71,10 +71,6 @@ class LogStash::Inputs::ZeroMQ < LogStash::Inputs::Base
   # example: `sockopt => ["ZMQ::HWM", 50, "ZMQ::IDENTITY", "my_named_queue"]`
   config :sockopt, :validate => :hash
 
-  # Defines if zeromq return code EAGAIN is an error
-  # May be used e.g. if ZMQ::RCVTIMEO is set
-  config :eagain_not_error, :validate => :boolean, :default => false
-
   public
   def register
     require "ffi-rzmq"
@@ -137,26 +133,24 @@ class LogStash::Inputs::ZeroMQ < LogStash::Inputs::Base
         # Get the first part as the msg
         m1 = ""
         rc = @zsocket.recv_string(m1)
-        error_check(rc, "in recv_string", @eagain_not_error)
-        if ZMQ::Util.resultcode_ok?(rc)
-          @logger.debug("ZMQ receiving", :event => m1)
-          msg = m1
-          # If we have more parts, we'll eat the first as the topic
-          # and set the message to the second part
-          if @zsocket.more_parts?
-            @logger.debug("Multipart message detected. Setting @message to second part. First part was: #{m1}")
-            m2 = ''
-            rc2 = @zsocket.recv_string(m2)
-            error_check(rc2, "in recv_string", @eagain_not_error)
-            @logger.debug("ZMQ receiving", :event => m2)
-            msg = m2
-          end
+        error_check(rc, "in recv_string")
+        @logger.debug("ZMQ receiving", :event => m1)
+        msg = m1
+        # If we have more parts, we'll eat the first as the topic
+        # and set the message to the second part
+        if @zsocket.more_parts?
+          @logger.debug("Multipart message detected. Setting @message to second part. First part was: #{m1}")
+          m2 = ''
+          rc2 = @zsocket.recv_string(m2)
+          error_check(rc2, "in recv_string")
+          @logger.debug("ZMQ receiving", :event => m2)
+          msg = m2
+        end
 
-          @codec.decode(msg) do |event|
-            event["host"] ||= host
-            decorate(event)
-            output_queue << event
-          end
+        @codec.decode(msg) do |event|
+          event["host"] ||= host
+          decorate(event)
+          output_queue << event
         end
       end
     rescue LogStash::ShutdownSignal

--- a/lib/logstash/inputs/zeromq.rb
+++ b/lib/logstash/inputs/zeromq.rb
@@ -114,7 +114,11 @@ class LogStash::Inputs::ZeroMQ < LogStash::Inputs::Base
   end # def register
 
   def teardown
-    error_check(@zsocket.close, "while closing the zmq socket")
+    begin
+      error_check(@zsocket.close, "while closing the zmq socket")
+    rescue RuntimeError => e
+      @logger.error("Failed to properly teardown ZeroMQ")
+    end
   end # def teardown
 
   def server?

--- a/lib/logstash/inputs/zeromq.rb
+++ b/lib/logstash/inputs/zeromq.rb
@@ -71,6 +71,10 @@ class LogStash::Inputs::ZeroMQ < LogStash::Inputs::Base
   # example: `sockopt => ["ZMQ::HWM", 50, "ZMQ::IDENTITY", "my_named_queue"]`
   config :sockopt, :validate => :hash
 
+  # Defines if zeromq return code EAGAIN is an error
+  # May be used e.g. if ZMQ::RCVTIMEO is set
+  config :eagain_not_error, :validate => :boolean, :default => false
+
   public
   def register
     require "ffi-rzmq"
@@ -129,24 +133,26 @@ class LogStash::Inputs::ZeroMQ < LogStash::Inputs::Base
         # Get the first part as the msg
         m1 = ""
         rc = @zsocket.recv_string(m1)
-        error_check(rc, "in recv_string")
-        @logger.debug("ZMQ receiving", :event => m1)
-        msg = m1
-        # If we have more parts, we'll eat the first as the topic
-        # and set the message to the second part
-        if @zsocket.more_parts?
-          @logger.debug("Multipart message detected. Setting @message to second part. First part was: #{m1}")
-          m2 = ''
-          rc2 = @zsocket.recv_string(m2)
-          error_check(rc2, "in recv_string")
-          @logger.debug("ZMQ receiving", :event => m2)
-          msg = m2
-        end
+        error_check(rc, "in recv_string", @eagain_not_error)
+        if ZMQ::Util.resultcode_ok?(rc)
+          @logger.debug("ZMQ receiving", :event => m1)
+          msg = m1
+          # If we have more parts, we'll eat the first as the topic
+          # and set the message to the second part
+          if @zsocket.more_parts?
+            @logger.debug("Multipart message detected. Setting @message to second part. First part was: #{m1}")
+            m2 = ''
+            rc2 = @zsocket.recv_string(m2)
+            error_check(rc2, "in recv_string", @eagain_not_error)
+            @logger.debug("ZMQ receiving", :event => m2)
+            msg = m2
+          end
 
-        @codec.decode(msg) do |event|
-          event["host"] ||= host
-          decorate(event)
-          output_queue << event
+          @codec.decode(msg) do |event|
+            event["host"] ||= host
+            decorate(event)
+            output_queue << event
+          end
         end
       end
     rescue LogStash::ShutdownSignal

--- a/lib/logstash/util/zeromq.rb
+++ b/lib/logstash/util/zeromq.rb
@@ -21,8 +21,8 @@ module LogStash::Util::ZeroMQ
     @logger.info("0mq: #{server? ? 'connected' : 'bound'}", :address => address)
   end
 
-  def error_check(rc, doing)
-    unless ZMQ::Util.resultcode_ok?(rc)
+  def error_check(rc, doing, eagain_not_error = false)
+    unless ZMQ::Util.resultcode_ok?(rc) || (ZMQ::Util.errno == ZMQ::EAGAIN && eagain_not_error)
       @logger.error("ZeroMQ error while #{doing}", { :error_code => rc })
       raise "ZeroMQ Error while #{doing}"
     end

--- a/lib/logstash/util/zeromq.rb
+++ b/lib/logstash/util/zeromq.rb
@@ -21,8 +21,8 @@ module LogStash::Util::ZeroMQ
     @logger.info("0mq: #{server? ? 'connected' : 'bound'}", :address => address)
   end
 
-  def error_check(rc, doing, eagain_not_error = false)
-    unless ZMQ::Util.resultcode_ok?(rc) || (ZMQ::Util.errno == ZMQ::EAGAIN && eagain_not_error)
+  def error_check(rc, doing)
+    unless ZMQ::Util.resultcode_ok?(rc)
       @logger.error("ZeroMQ error while #{doing}", { :error_code => rc })
       raise "ZeroMQ Error while #{doing}"
     end


### PR DESCRIPTION
There are irregularly situations where ZeroMQ raises an exception on
close. There is no need to stop logstash with RuntimeError and
stack backtrace if logstash is already tearing down.

The problem seems to be logstash closing an already closed ZeroMQ
socket.

May be related to #5
