### PR TITLE
Bugfix for uninterrupted receive loop

### DIFF
--- a/lib/logstash/inputs/zeromq.rb
+++ b/lib/logstash/inputs/zeromq.rb
@@ -68,11 +68,16 @@ class LogStash::Inputs::ZeroMQ < LogStash::Inputs::Base
   #  * `ZMQ::IDENTITY` - named queues
   #  * `ZMQ::SWAP_SIZE` - space for disk overflow
   #
-  # example: `sockopt => ["ZMQ::HWM", 50, "ZMQ::IDENTITY", "my_named_queue"]`
+  # Example:
+  # [source,ruby]
+  #     sockopt => {
+  #        "ZMQ::HWM" => 50
+  #        "ZMQ::IDENTITY"  => "my_named_queue"
+  #     }
   #
-  # defaults to: `sockopt => ["ZMQ::RCVTIMEO", "1000"]`, which has the effect of "interrupting"
+  # defaults to: `sockopt => { "ZMQ::RCVTIMEO" => "1000" }`, which has the effect of "interrupting"
   # the recv operation at least once every second to allow for properly shutdown handling.
-  config :sockopt, :validate => :hash, :default => [ "ZMQ::RCVTIMEO", "1000" ]
+  config :sockopt, :validate => :hash, :default => { "ZMQ::RCVTIMEO" => "1000" }
 
   public
   def register

--- a/lib/logstash/inputs/zeromq.rb
+++ b/lib/logstash/inputs/zeromq.rb
@@ -130,8 +130,8 @@ class LogStash::Inputs::ZeroMQ < LogStash::Inputs::Base
         # Get the first part as the msg
         m1 = ""
         rc = @zsocket.recv_string(m1, ZMQ::DONTWAIT)
-        next if rc == -1 && ZMQ::Util.errno == ZMQ::EAGAIN
-        error_check(rc, "in recv_string")
+        error_check(rc, "in recv_string", true)
+        next unless ZMQ::Util.resultcode_ok?(rc)
 
         @logger.debug("ZMQ receiving", :event => m1)
         msg = m1

--- a/lib/logstash/inputs/zeromq.rb
+++ b/lib/logstash/inputs/zeromq.rb
@@ -69,7 +69,10 @@ class LogStash::Inputs::ZeroMQ < LogStash::Inputs::Base
   #  * `ZMQ::SWAP_SIZE` - space for disk overflow
   #
   # example: `sockopt => ["ZMQ::HWM", 50, "ZMQ::IDENTITY", "my_named_queue"]`
-  config :sockopt, :validate => :hash
+  #
+  # defaults to: `sockopt => ["ZMQ::RCVTIMEO", "1000"]`, which has the effect of "interrupting"
+  # the recv operation at least once every second to allow for properly shutdown handling.
+  config :sockopt, :validate => :hash, :default => [ "ZMQ::RCVTIMEO", "1000" ]
 
   public
   def register
@@ -129,7 +132,7 @@ class LogStash::Inputs::ZeroMQ < LogStash::Inputs::Base
         # Here's the unified receiver
         # Get the first part as the msg
         m1 = ""
-        rc = @zsocket.recv_string(m1, ZMQ::DONTWAIT)
+        rc = @zsocket.recv_string(m1)
         error_check(rc, "in recv_string", true)
         next unless ZMQ::Util.resultcode_ok?(rc)
 
@@ -141,7 +144,7 @@ class LogStash::Inputs::ZeroMQ < LogStash::Inputs::Base
           @logger.debug("Multipart message detected. Setting @message to second part. First part was: #{m1}")
           m2 = ''
           rc2 = @zsocket.recv_string(m2)
-          error_check(rc2, "in recv_string")
+          error_check(rc2, "in recv_string", true)
           @logger.debug("ZMQ receiving", :event => m2)
           msg = m2
         end

--- a/lib/logstash/util/zeromq.rb
+++ b/lib/logstash/util/zeromq.rb
@@ -20,8 +20,8 @@ module LogStash::Util::ZeroMQ
     @logger.info("0mq: #{server? ? 'connected' : 'bound'}", :address => address)
   end
 
-  def error_check(rc, doing)
-    unless ZMQ::Util.resultcode_ok?(rc)
+  def error_check(rc, doing, eagain_not_error = false)
+    unless ZMQ::Util.resultcode_ok?(rc) || (ZMQ::Util.errno == ZMQ::EAGAIN && eagain_not_error)
       @logger.error("ZeroMQ error while #{doing}", { :error_code => rc })
       raise "ZeroMQ Error while #{doing}"
     end


### PR DESCRIPTION
Replace the uninterrupted receive loop (non-blocking) with
a blocking loop with a default timeout of 1000ms.

Restores compatibility with zeromq output plugin for util/zeromq.rb as well, if logstash-plugins/logstash-output-zeromq#13 is merged.

Closes #17 
May also be related to #5 
